### PR TITLE
Fix default code

### DIFF
--- a/src/features/collections/default-code.ts
+++ b/src/features/collections/default-code.ts
@@ -10,13 +10,14 @@ export const DEFAULT_CODE = (name: string) => `// This is an example collection 
 // \`public\` means that the collection is public, anyone can view and read
 // the records in the collection. You can still implement rules on who can 
 // edit the data by defining functions on the collection.
+@public
 collection ${name} {
   // \`id\` is unique and required on all collections
   id: string;
 
   // We will use a public key to authenticate function
   // calls later
-  publicKey: string;
+  publicKey: PublicKey;
 
   // A mandatory property
   name: string; 


### PR DESCRIPTION
Note: previously with `string`, `publicKey` would be set to an empty string, so you could create a record without auth. With PublicKey this will throw, because publicKey will be undefined. To get the same behavior, we would need to change `publicKey` to be optional and add `if (ctx.publicKey) this.publicKey = ctx.publicKey`

https://linear.app/polybase/issue/ENG-361/invalid-explorer-default-code