### PR TITLE
Fix false showing up as `-` in collection record data

### DIFF
--- a/src/features/collections/CollectionDetailData.tsx
+++ b/src/features/collections/CollectionDetailData.tsx
@@ -45,7 +45,11 @@ export function CollectionDetailData({ collectionId }: CollectionDetailDataProps
       accessor: `data.${field.name}`,
       Header: field.name,
       Cell: ({ cell }: { cell: Cell<any> }) => {
-        const str = cell.value ? JSON.stringify(cell.value) : '-'
+        const str =
+          cell.value === undefined
+            ? '-'
+            : JSON.stringify(cell.value)
+
         return <Box>{str.length > 100 ? `${str.substring(0, 100)}...` : str}</Box>
       },
     }


### PR DESCRIPTION
Do we want to bump the polybase patch version for this and update docs?

Just `cell.value === undefined` worked, so I went with that. I think showing `null` makes sense, if that's what you would get from the JSON.